### PR TITLE
Add exception case testing for LL.sol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ out
 gen
 
 .openzeppelin/.session
+.DS_Store
+coverageEnv/

--- a/contracts/modules/book-room/TestLLrevert.sol
+++ b/contracts/modules/book-room/TestLLrevert.sol
@@ -9,9 +9,20 @@ contract TestLLrevert {
     address constant CAT1 = 0xb04aD816e86bFA5515c35Ad02081F71D9E848C88;
     address constant CAT2 = 0x633eC0587Aee0cFEC883cAB73cEf822230C54d3a;
 
-    function testRevert() public {
+    function initLL() public {
         cats = cats.init();
+    }
+
+    function testDupAddRevert() public {
         cats = cats.add(CAT1);
         cats = cats.add(CAT1);
+    }
+
+    function testRemoveNoExistRevert() public {
+        cats = cats.remove(CAT2, CAT1);
+    }
+
+    function testRemoveWrongPreRevert() public {
+        cats = cats.remove(CAT1, CAT2);
     }
 }

--- a/contracts/modules/book-room/TestLLrevert.sol
+++ b/contracts/modules/book-room/TestLLrevert.sol
@@ -23,6 +23,7 @@ contract TestLLrevert {
     }
 
     function testRemoveWrongPreRevert() public {
-        cats = cats.remove(CAT1, CAT2);
+        cats = cats.add(CAT2);
+        cats = cats.remove(CAT2, CAT1);
     }
 }

--- a/contracts/modules/book-room/TestLLrevert.sol
+++ b/contracts/modules/book-room/TestLLrevert.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.5.0;
+
+import "../../../contracts/modules/book-room/LL.sol";
+
+contract TestLLrevert {
+    LL.List public cats;
+    using LL for LL.List;
+
+    address constant CAT1 = 0xb04aD816e86bFA5515c35Ad02081F71D9E848C88;
+    address constant CAT2 = 0x633eC0587Aee0cFEC883cAB73cEf822230C54d3a;
+
+    function testRevert() public {
+        cats = cats.init();
+        cats = cats.add(CAT1);
+        cats = cats.add(CAT1);
+    }
+}

--- a/test/js/book-room/TestLL.js
+++ b/test/js/book-room/TestLL.js
@@ -2,21 +2,27 @@ const TestLLrevert = artifacts.require("TestLLrevert");
 
 contract("LL", async accounts => {
     let testLLrevert;
-    let item2 = accounts[0];
     let catchRevert = require("../testhelper/exceptions.js").catchRevert;
   
     beforeEach(async () => {
         testLLrevert = await TestLLrevert.new(accounts);
+        testLLrevert.initLL();
     });
 
     describe("TestLL and LL contract, assertion revert test:", function() {
-        before(async function() {
-            testLLrevert = await TestLLrevert.new();
+        it("should fail with revert", async function() {
+            // expected error messsage "addr is already in the list"
+            await catchRevert(testLLrevert.testDupAddRevert());
         });
 
-        it("should abort with an revert", async function() {
-            // should fail with revert messsage "addr is already in the list"
-            await catchRevert(testLLrevert.testRevert());
+        it("should fail with revert", async function() {
+            // expected error messsage "addr not whitelisted yet."
+            await catchRevert(testLLrevert.testRemoveNoExistRevert());
+        });
+
+        it("should fail with revert", async function() {
+            // expected error messsage "wrong prevConsumer."
+            await catchRevert(testLLrevert.testRemoveNoExistRevert());
         });
     });
 });

--- a/test/js/book-room/TestLL.js
+++ b/test/js/book-room/TestLL.js
@@ -1,0 +1,26 @@
+const LL = artifacts.require("LL");
+
+contract("LL", async accounts => {
+    let ll;
+    let item1 = accounts[0];
+    let item2 = accounts[1];
+    let catchRevert = require("../testhelper/exceptions.js").catchRevert;
+  
+    beforeEach(async () => {
+      ll = await LL.new(accounts);
+    });
+
+    describe("LL add assertion:", function() {
+        before(async function() {
+            ll = await LL.new();
+        });
+        it("should complete successfully", async function() {
+            await ll.add(item1); // should add successfully
+            await ll.add(item2); // should add successfully
+            assert.equal(ll[1], item1, "item1 is the 1st item");
+        });
+        it("should abort with an revert", async function() {
+            await catchRevert(ll.add(item1)); // should fail with revert messsage "addr is already in the list"
+        });
+    });
+});

--- a/test/js/book-room/TestLL.js
+++ b/test/js/book-room/TestLL.js
@@ -1,26 +1,22 @@
-const LL = artifacts.require("LL");
+const TestLLrevert = artifacts.require("TestLLrevert");
 
 contract("LL", async accounts => {
-    let ll;
-    let item1 = accounts[0];
-    let item2 = accounts[1];
+    let testLLrevert;
+    let item2 = accounts[0];
     let catchRevert = require("../testhelper/exceptions.js").catchRevert;
   
     beforeEach(async () => {
-      ll = await LL.new(accounts);
+        testLLrevert = await TestLLrevert.new(accounts);
     });
 
-    describe("LL add assertion:", function() {
+    describe("TestLL and LL contract, assertion revert test:", function() {
         before(async function() {
-            ll = await LL.new();
+            testLLrevert = await TestLLrevert.new();
         });
-        it("should complete successfully", async function() {
-            await ll.add(item1); // should add successfully
-            await ll.add(item2); // should add successfully
-            assert.equal(ll[1], item1, "item1 is the 1st item");
-        });
+
         it("should abort with an revert", async function() {
-            await catchRevert(ll.add(item1)); // should fail with revert messsage "addr is already in the list"
+            // should fail with revert messsage "addr is already in the list"
+            await catchRevert(testLLrevert.testRevert());
         });
     });
 });

--- a/test/js/book-room/TestLL.js
+++ b/test/js/book-room/TestLL.js
@@ -22,7 +22,7 @@ contract("LL", async accounts => {
 
         it("should fail with revert", async function() {
             // expected error messsage "wrong prevConsumer."
-            await catchRevert(testLLrevert.testRemoveNoExistRevert());
+            await catchRevert(testLLrevert.testRemoveWrongPreRevert());
         });
     });
 });

--- a/test/js/testhelper/exceptions.js
+++ b/test/js/testhelper/exceptions.js
@@ -1,0 +1,22 @@
+const PREFIX = "VM Exception while processing transaction: ";
+
+async function tryCatch(promise, message) {
+    try {
+        await promise;
+        throw null;
+    }
+    catch (error) {
+        assert(error, "Expected an error but did not get one");
+        assert(error.message.startsWith(PREFIX + message), "Expected an error starting with '" + PREFIX + message + "' but got '" + error.message + "' instead");
+    }
+};
+
+module.exports = {
+    catchRevert            : async function(promise) {await tryCatch(promise, "revert"             );},
+    catchOutOfGas          : async function(promise) {await tryCatch(promise, "out of gas"         );},
+    catchInvalidJump       : async function(promise) {await tryCatch(promise, "invalid JUMP"       );},
+    catchInvalidOpcode     : async function(promise) {await tryCatch(promise, "invalid opcode"     );},
+    catchStackOverflow     : async function(promise) {await tryCatch(promise, "stack overflow"     );},
+    catchStackUnderflow    : async function(promise) {await tryCatch(promise, "stack underflow"    );},
+    catchStaticStateChange : async function(promise) {await tryCatch(promise, "static state change");},
+};

--- a/test/js/testhelper/exceptions.js
+++ b/test/js/testhelper/exceptions.js
@@ -1,4 +1,5 @@
-const PREFIX = "VM Exception while processing transaction: ";
+const ALREADY_INTHELIST_ERROR = 
+    "Returned error: VM Exception while processing transaction: revert addr is already in the list -- Reason given: addr is already in the list.";
 
 async function tryCatch(promise, message) {
     try {
@@ -7,7 +8,10 @@ async function tryCatch(promise, message) {
     }
     catch (error) {
         assert(error, "Expected an error but did not get one");
-        assert(error.message.startsWith(PREFIX + message), "Expected an error starting with '" + PREFIX + message + "' but got '" + error.message + "' instead");
+        assert(
+            error.message === ALREADY_INTHELIST_ERROR, 
+            "Expected an error message: '" + ALREADY_INTHELIST_ERROR + "' but got '" + error.message + "' instead",
+            );
     }
 };
 

--- a/test/js/testhelper/exceptions.js
+++ b/test/js/testhelper/exceptions.js
@@ -1,5 +1,4 @@
-const ALREADY_INTHELIST_ERROR = 
-    "Returned error: VM Exception while processing transaction: revert addr is already in the list -- Reason given: addr is already in the list.";
+const ERROR_PREFIX = "Returned error: VM Exception while processing transaction:";
 
 async function tryCatch(promise, message) {
     try {
@@ -9,8 +8,8 @@ async function tryCatch(promise, message) {
     catch (error) {
         assert(error, "Expected an error but did not get one");
         assert(
-            error.message === ALREADY_INTHELIST_ERROR, 
-            "Expected an error message: '" + ALREADY_INTHELIST_ERROR + "' but got '" + error.message + "' instead",
+            error.message.startsWith(ERROR_PREFIX), 
+            "Expected an error message like '" + ERROR_PREFIX + "' but got '" + error.message + "' instead",
             );
     }
 };


### PR DESCRIPTION
1. Created TestLLrevert.sol to mock revert cases in LL.sol
2. Created exceptions.js to catch exceptions using JS promise
3. Created TestLL.js that calls TestLLrevert.sol and match error messages against the expected value. 

To test: 

	truffle test ./test/js/book-room/TestLL.js

Result: 

	Using network 'test'.


	Compiling your contracts...
	===========================
	> Compiling ./contracts/modules/book-room/LL.sol
	> Compiling ./contracts/modules/book-room/TestLLrevert.sol
	> Compiling ./contracts/modules/core/Heart.sol
	> Compiling ./contracts/modules/core/Token.sol
	> Compiling ./contracts/modules/voracle/Lag.sol
	> Compiling ./contracts/modules/voracle/Med.sol



	  Contract: LL
	    TestLL and LL contract, assertion revert test:
	      ✓ should fail with revert (141ms)
	      ✓ should fail with revert (102ms)
	      ✓ should fail with revert (107ms)


	  3 passing (1s)

Coverage report for LL.sol: 

    yarn test:cov

<img width="865" alt="Screen Shot 2020-01-18 at 12 05 43" src="https://user-images.githubusercontent.com/952442/72657796-3146a580-39ec-11ea-9dee-449fa2eb939a.png">
