### PR TITLE
Exception case testing for LL.sol (#33 continued)

### DIFF
--- a/contracts/modules/testhelper/TestLLrevert.sol
+++ b/contracts/modules/testhelper/TestLLrevert.sol
@@ -1,0 +1,29 @@
+pragma solidity ^0.5.0;
+
+import "../../../contracts/modules/book-room/LL.sol";
+
+contract TestLLrevert {
+    LL.List public cats;
+    using LL for LL.List;
+
+    address constant CAT1 = 0xb04aD816e86bFA5515c35Ad02081F71D9E848C88;
+    address constant CAT2 = 0x633eC0587Aee0cFEC883cAB73cEf822230C54d3a;
+
+    function initLL() public {
+        cats = cats.init();
+    }
+
+    function testDupAddRevert() public {
+        cats = cats.add(CAT1);
+        cats = cats.add(CAT1);
+    }
+
+    function testRemoveNoExistRevert() public {
+        cats = cats.remove(CAT2, CAT1);
+    }
+
+    function testRemoveWrongPreRevert() public {
+        cats = cats.add(CAT2);
+        cats = cats.remove(CAT2, CAT1);
+    }
+}

--- a/contracts/modules/testhelper/TestLLrevert.sol
+++ b/contracts/modules/testhelper/TestLLrevert.sol
@@ -13,16 +13,16 @@ contract TestLLrevert {
         cats = cats.init();
     }
 
-    function testDupAddRevert() public {
+    function llDupAddRevert() public {
         cats = cats.add(CAT1);
         cats = cats.add(CAT1);
     }
 
-    function testRemoveNoExistRevert() public {
+    function llRemoveNoExistRevert() public {
         cats = cats.remove(CAT2, CAT1);
     }
 
-    function testRemoveWrongPreRevert() public {
+    function llRemoveWrongPreRevert() public {
         cats = cats.add(CAT2);
         cats = cats.remove(CAT2, CAT1);
     }

--- a/test/js/book-room/TestLL.js
+++ b/test/js/book-room/TestLL.js
@@ -12,17 +12,17 @@ contract("LL", async accounts => {
     describe("TestLL and LL contract, assertion revert test:", function() {
         it("should fail with revert", async function() {
             // expected error messsage "addr is already in the list"
-            await catchRevert(testLLrevert.testDupAddRevert());
+            await catchRevert(testLLrevert.llDupAddRevert());
         });
 
         it("should fail with revert", async function() {
             // expected error messsage "addr not whitelisted yet."
-            await catchRevert(testLLrevert.testRemoveNoExistRevert());
+            await catchRevert(testLLrevert.llRemoveNoExistRevert());
         });
 
         it("should fail with revert", async function() {
             // expected error messsage "wrong prevConsumer."
-            await catchRevert(testLLrevert.testRemoveWrongPreRevert());
+            await catchRevert(testLLrevert.llRemoveWrongPreRevert());
         });
     });
 });

--- a/test/js/book-room/TestLL.js
+++ b/test/js/book-room/TestLL.js
@@ -1,0 +1,28 @@
+const TestLLrevert = artifacts.require("TestLLrevert");
+
+contract("LL", async accounts => {
+    let testLLrevert;
+    let catchRevert = require("../testhelper/exceptions.js").catchRevert;
+
+    beforeEach(async () => {
+        testLLrevert = await TestLLrevert.new(accounts);
+        testLLrevert.initLL();
+    });
+
+    describe("TestLL and LL contract, assertion revert test:", function() {
+        it("should fail with revert", async function() {
+            // expected error messsage "addr is already in the list"
+            await catchRevert(testLLrevert.testDupAddRevert());
+        });
+
+        it("should fail with revert", async function() {
+            // expected error messsage "addr not whitelisted yet."
+            await catchRevert(testLLrevert.testRemoveNoExistRevert());
+        });
+
+        it("should fail with revert", async function() {
+            // expected error messsage "wrong prevConsumer."
+            await catchRevert(testLLrevert.testRemoveWrongPreRevert());
+        });
+    });
+});

--- a/test/js/testhelper/exceptions.js
+++ b/test/js/testhelper/exceptions.js
@@ -1,0 +1,25 @@
+const ERROR_PREFIX = "Returned error: VM Exception while processing transaction:";
+
+async function tryCatch(promise, message) {
+    try {
+        await promise;
+        throw null;
+    }
+    catch (error) {
+        assert(error, "Expected an error but did not get one");
+        assert(
+            error.message.startsWith(ERROR_PREFIX), 
+            "Expected an error message like '" + ERROR_PREFIX + "' but got '" + error.message + "' instead",
+            );
+    }
+};
+
+module.exports = {
+    catchRevert            : async function(promise) {await tryCatch(promise, "revert"             );},
+    catchOutOfGas          : async function(promise) {await tryCatch(promise, "out of gas"         );},
+    catchInvalidJump       : async function(promise) {await tryCatch(promise, "invalid JUMP"       );},
+    catchInvalidOpcode     : async function(promise) {await tryCatch(promise, "invalid opcode"     );},
+    catchStackOverflow     : async function(promise) {await tryCatch(promise, "stack overflow"     );},
+    catchStackUnderflow    : async function(promise) {await tryCatch(promise, "stack underflow"    );},
+    catchStaticStateChange : async function(promise) {await tryCatch(promise, "static state change");},
+};


### PR DESCRIPTION
This is to replace (there are some merge-conflicts that I wasn't able to resolve): 

https://github.com/velo-protocol/DRSv2/pull/33

Changes made: 

Moved contracts/modules/**book-room**/TestLLrevert.sol to contracts/modules/**testhelper**/TestLLrevert.sol

Also, changed function prefix "test" in **TestLLrevert.sol**

Testing:

truffle test test/js/book-room/TestLL.js
yarn test:cov

<img width="984" alt="Screen Shot 2020-01-21 at 16 09 45" src="https://user-images.githubusercontent.com/952442/72783170-1df43e00-3c69-11ea-806c-4b82399008af.png">

<img width="982" alt="Screen Shot 2020-01-21 at 16 09 52" src="https://user-images.githubusercontent.com/952442/72783172-1df43e00-3c69-11ea-8fd2-98dfee2a12c2.png">

<img width="976" alt="Screen Shot 2020-01-21 at 16 09 59" src="https://user-images.githubusercontent.com/952442/72783173-1e8cd480-3c69-11ea-84c2-5ac382b6da88.png">

