### PR TITLE
Redeem integration test velo667

### DIFF
--- a/go/libs/vclient/mocks/mocked_interfaces.go
+++ b/go/libs/vclient/mocks/mocked_interfaces.go
@@ -6,12 +6,12 @@ package mocks
 
 import (
 	context "context"
-	go_ethereum "github.com/ethereum/go-ethereum"
+	ethereum "github.com/ethereum/go-ethereum"
 	bind "github.com/ethereum/go-ethereum/accounts/abi/bind"
 	common "github.com/ethereum/go-ethereum/common"
 	types "github.com/ethereum/go-ethereum/core/types"
 	gomock "github.com/golang/mock/gomock"
-	abi "github.com/velo-protocol/DRSv2/go/abi"
+	vabi "github.com/velo-protocol/DRSv2/go/abi"
 	big "math/big"
 	reflect "reflect"
 )
@@ -55,7 +55,7 @@ func (mr *MockConnectionMockRecorder) CodeAt(ctx, contract, blockNumber interfac
 }
 
 // CallContract mocks base method
-func (m *MockConnection) CallContract(ctx context.Context, call go_ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+func (m *MockConnection) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CallContract", ctx, call, blockNumber)
 	ret0, _ := ret[0].([]byte)
@@ -115,7 +115,7 @@ func (mr *MockConnectionMockRecorder) SuggestGasPrice(ctx interface{}) *gomock.C
 }
 
 // EstimateGas mocks base method
-func (m *MockConnection) EstimateGas(ctx context.Context, call go_ethereum.CallMsg) (uint64, error) {
+func (m *MockConnection) EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EstimateGas", ctx, call)
 	ret0, _ := ret[0].(uint64)
@@ -144,7 +144,7 @@ func (mr *MockConnectionMockRecorder) SendTransaction(ctx, tx interface{}) *gomo
 }
 
 // FilterLogs mocks base method
-func (m *MockConnection) FilterLogs(ctx context.Context, query go_ethereum.FilterQuery) ([]types.Log, error) {
+func (m *MockConnection) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FilterLogs", ctx, query)
 	ret0, _ := ret[0].([]types.Log)
@@ -159,10 +159,10 @@ func (mr *MockConnectionMockRecorder) FilterLogs(ctx, query interface{}) *gomock
 }
 
 // SubscribeFilterLogs mocks base method
-func (m *MockConnection) SubscribeFilterLogs(ctx context.Context, query go_ethereum.FilterQuery, ch chan<- types.Log) (go_ethereum.Subscription, error) {
+func (m *MockConnection) SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubscribeFilterLogs", ctx, query, ch)
-	ret0, _ := ret[0].(go_ethereum.Subscription)
+	ret0, _ := ret[0].(ethereum.Subscription)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -526,10 +526,10 @@ func (mr *MockTxHelperMockRecorder) ConfirmTx(ctx, tx interface{}) *gomock.Call 
 }
 
 // ExtractSetupEvent mocks base method
-func (m *MockTxHelper) ExtractSetupEvent(eventName string, log *types.Log) (*abi.DigitalReserveSystemSetup, error) {
+func (m *MockTxHelper) ExtractSetupEvent(eventName string, log *types.Log) (*vabi.DigitalReserveSystemSetup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExtractSetupEvent", eventName, log)
-	ret0, _ := ret[0].(*abi.DigitalReserveSystemSetup)
+	ret0, _ := ret[0].(*vabi.DigitalReserveSystemSetup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -541,10 +541,10 @@ func (mr *MockTxHelperMockRecorder) ExtractSetupEvent(eventName, log interface{}
 }
 
 // ExtractMintEvent mocks base method
-func (m *MockTxHelper) ExtractMintEvent(eventName string, log *types.Log) (*abi.DigitalReserveSystemMint, error) {
+func (m *MockTxHelper) ExtractMintEvent(eventName string, log *types.Log) (*vabi.DigitalReserveSystemMint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExtractMintEvent", eventName, log)
-	ret0, _ := ret[0].(*abi.DigitalReserveSystemMint)
+	ret0, _ := ret[0].(*vabi.DigitalReserveSystemMint)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -556,10 +556,10 @@ func (mr *MockTxHelperMockRecorder) ExtractMintEvent(eventName, log interface{})
 }
 
 // ExtractRedeemEvent mocks base method
-func (m *MockTxHelper) ExtractRedeemEvent(eventName string, log *types.Log) (*abi.DigitalReserveSystemRedeem, error) {
+func (m *MockTxHelper) ExtractRedeemEvent(eventName string, log *types.Log) (*vabi.DigitalReserveSystemRedeem, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExtractRedeemEvent", eventName, log)
-	ret0, _ := ret[0].(*abi.DigitalReserveSystemRedeem)
+	ret0, _ := ret[0].(*vabi.DigitalReserveSystemRedeem)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/go/libs/vclient/redeem_stable_credit.go
+++ b/go/libs/vclient/redeem_stable_credit.go
@@ -90,7 +90,9 @@ func (c *Client) RedeemStableCredit(ctx context.Context, input *RedeemStableCred
 		abiInput.RedeemAmount,
 		abiInput.AssetCode,
 	)
-
+	if err != nil {
+		return nil, err
+	}
 	receipt, err := c.txHelper.ConfirmTx(ctx, tx)
 	if err != nil {
 		return nil, err

--- a/go/libs/vclient/redeem_stable_credit_example_test.go
+++ b/go/libs/vclient/redeem_stable_credit_example_test.go
@@ -1,0 +1,45 @@
+// +build !unit
+
+package vclient
+
+import (
+	"context"
+	"log"
+)
+
+func ExampleClient_RedeemStableCredit() {
+	client, err := NewClient(smartContractUrl, "b68a7d2260076d2e73f295cc0d946c76db7f6d96f184ea00e97376680a29749a", ContractAddress{
+		DrsAddress:   "0xE5352EB3a0FA6C897da1F5FfB90d57AbA099F5bB",   // 0xBdA518a6245480652d1A217192EBB299C94F623f
+		HeartAddress: "0xF9baEAdFC5e0CAbC0c1E5E88571c2d7a75099Df1", // 0x1623C9c8600319E7CfAff0Ca1c4a05e1a61D954D
+	})
+	//client, err := NewClient(smartContractUrl, "<PRIVATE_KEY>", ContractAddress{
+	//	DrsAddress:   "<DRS_CONTRACT_ADDRESS>",   // 0xBdA518a6245480652d1A217192EBB299C94F623f
+	//	HeartAddress: "<HEART_CONTRACT_ADDRESS>", // 0x1623C9c8600319E7CfAff0Ca1c4a05e1a61D954D
+	//})
+
+	if err != nil {
+		panic(err)
+	}
+
+	result, err := client.RedeemStableCredit(context.Background(), &RedeemStableCreditInput{
+		RedeemAmount:"104",
+		AssetCode:  "vUSD",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	log.Println("Redeem Stable Credit Transaction Hash: ", result.Tx.Hash().String())
+	log.Println("Asset Code: ", result.Event.AssetCode)
+	log.Println("Stable Credit Amount: ", result.Event.StableCreditAmount)
+	log.Println("Collateral Asset Address: ", result.Event.CollateralAssetAddress)
+	log.Println("Collateral Asset Code: ", result.Event.CollateralAssetCode)
+	log.Println("Collateral Amount: ", result.Event.CollateralAmount)
+	// Output:
+	// Mint From Stable Credit Amount Transaction Hash: 0x1afaa6fc22b88f875bb16235128e245589fa460f8325f84ace2d89bb4204204b
+	// Asset Address: 0x23Cf6f4656218Bd25733f27aadBEe009A0f6C3Fd
+	// Asset Code: vUSD
+	// Collateral Amount: 0.2736842
+	// Collateral Asset Code: VELO
+	// Mint Amount: 2.0000000
+}

--- a/go/libs/vclient/redeem_stable_credit_example_test.go
+++ b/go/libs/vclient/redeem_stable_credit_example_test.go
@@ -8,14 +8,10 @@ import (
 )
 
 func ExampleClient_RedeemStableCredit() {
-	client, err := NewClient(smartContractUrl, "b68a7d2260076d2e73f295cc0d946c76db7f6d96f184ea00e97376680a29749a", ContractAddress{
-		DrsAddress:   "0xE5352EB3a0FA6C897da1F5FfB90d57AbA099F5bB",   // 0xBdA518a6245480652d1A217192EBB299C94F623f
-		HeartAddress: "0xF9baEAdFC5e0CAbC0c1E5E88571c2d7a75099Df1", // 0x1623C9c8600319E7CfAff0Ca1c4a05e1a61D954D
+	client, err := NewClient(smartContractUrl, "<PRIVATE_KEY>", ContractAddress{
+		DrsAddress:   "<DRS_CONTRACT_ADDRESS>",   // 0xBdA518a6245480652d1A217192EBB299C94F623f
+		HeartAddress: "<HEART_CONTRACT_ADDRESS>", // 0x1623C9c8600319E7CfAff0Ca1c4a05e1a61D954D
 	})
-	//client, err := NewClient(smartContractUrl, "<PRIVATE_KEY>", ContractAddress{
-	//	DrsAddress:   "<DRS_CONTRACT_ADDRESS>",   // 0xBdA518a6245480652d1A217192EBB299C94F623f
-	//	HeartAddress: "<HEART_CONTRACT_ADDRESS>", // 0x1623C9c8600319E7CfAff0Ca1c4a05e1a61D954D
-	//})
 
 	if err != nil {
 		panic(err)
@@ -35,11 +31,11 @@ func ExampleClient_RedeemStableCredit() {
 	log.Println("Collateral Asset Address: ", result.Event.CollateralAssetAddress)
 	log.Println("Collateral Asset Code: ", result.Event.CollateralAssetCode)
 	log.Println("Collateral Amount: ", result.Event.CollateralAmount)
-	// Output:
-	// Mint From Stable Credit Amount Transaction Hash: 0x1afaa6fc22b88f875bb16235128e245589fa460f8325f84ace2d89bb4204204b
-	// Asset Address: 0x23Cf6f4656218Bd25733f27aadBEe009A0f6C3Fd
-	// Asset Code: vUSD
-	// Collateral Amount: 0.2736842
-	// Collateral Asset Code: VELO
-	// Mint Amount: 2.0000000
+	//Output:
+	//Redeem Stable Credit Transaction Hash:  0xf9647f3e917d75f124876928fe60d015763fa807c621bf956167a37653197d4a
+	//Asset Code:  vUSD
+	//Stable Credit Amount:  104.0000000
+	//Collateral Asset Address:  0x11590aB398DD2fedC2C40b6E9F02fa13cC4d2dEe
+	//Collateral Asset Code:  VELO
+	//Collateral Amount:  0.0000000
 }

--- a/go/libs/vclient/redeem_stable_credit_test.go
+++ b/go/libs/vclient/redeem_stable_credit_test.go
@@ -119,6 +119,28 @@ func TestClient_RedeemStableCredit(t *testing.T) {
 		assert.Nil(t, result)
 	})
 
+	t.Run("error, Redeem() function returns an error", func(t *testing.T) {
+		testHelper := testHelperWithMock(t)
+		defer testHelper.MockController.Finish()
+
+		expectedMsg := "some error has occurred"
+
+		input := &RedeemStableCreditInput{
+			RedeemAmount: "104",
+			AssetCode:    "vUSD",
+		}
+		abiInput := input.ToAbiInput()
+
+		testHelper.MockDRSContract.EXPECT().
+			Redeem(gomock.AssignableToTypeOf(&bind.TransactOpts{}), abiInput.RedeemAmount, abiInput.AssetCode).
+			Return(nil, errors.New(expectedMsg))
+
+		result, err := testHelper.Client.RedeemStableCredit(context.Background(), input)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), expectedMsg)
+	})
+
 	t.Run("error, txHelper.ConfirmTx returns an error", func(t *testing.T) {
 		testHelper := testHelperWithMock(t)
 		defer testHelper.MockController.Finish()


### PR DESCRIPTION
Replace <PRIVATE_KEY>, <DRS_CONTRACT_ADDRESS> and <HEART_CONTRACT_ADDRESS>, and got: 

```
=== RUN   ExampleClient_RedeemStableCredit
2020/02/19 18:03:47 Redeem Stable Credit Transaction Hash:  0x01cf73a54068b5b1e60d008aa4c06f8a84ec64873babecf283112be13803752f
2020/02/19 18:03:47 Asset Code:  vUSD
2020/02/19 18:03:47 Stable Credit Amount:  10.0000000
2020/02/19 18:03:47 Collateral Asset Address:  0x11590aB398DD2fedC2C40b6E9F02fa13cC4d2dEe
2020/02/19 18:03:47 Collateral Asset Code:  VELO
2020/02/19 18:03:47 Collateral Amount:  0.0000000
--- FAIL: ExampleClient_RedeemStableCredit (0.20s)
```