### PR TITLE
TestLogic_RedeemStableCredit

### DIFF
--- a/contracts/modules/core/DigitalReserveSystem.sol
+++ b/contracts/modules/core/DigitalReserveSystem.sol
@@ -193,10 +193,7 @@ contract DigitalReserveSystem is IDRS {
 
         _rebalance(assetCode);
 
-        uint256 priceInCollateralPerAssetUnit = _calExchangeRate(stableCredit, linkId);
-
-        // collateralAmount = stableCreditAmount * priceInCollateralPerAssetUnit
-        uint256 collateralAmount = stableCreditAmount.mul(priceInCollateralPerAssetUnit).div(10000000);
+        uint256 collateralAmount = _calExchangeRate(stableCredit, linkId, stableCreditAmount);
 
         stableCredit.redeem(msg.sender, stableCreditAmount, collateralAmount);
         stableCredit.approveCollateral();
@@ -225,7 +222,7 @@ contract DigitalReserveSystem is IDRS {
 
         (IStableCredit stableCredit, , bytes32 collateralAssetCode, bytes32 linkId) = _validateAssetCode(assetCode);
 
-        (uint256 priceInCollateralPerAssetUnit) = _calExchangeRate(stableCredit, linkId);
+        (uint256 priceInCollateralPerAssetUnit) = _calExchangeRate(stableCredit, linkId, 10000000);
 
         return (assetCode, collateralAssetCode, priceInCollateralPerAssetUnit);
     }
@@ -335,9 +332,9 @@ contract DigitalReserveSystem is IDRS {
         return creditAmount.mul(credit.peggedValue().mul(collateralRatio)).div(heart.getPriceFeeders().getMedianPrice(linkId));
     }
 
-    function _calExchangeRate(IStableCredit credit, bytes32 linkId) private view returns (uint256) {
-        // priceInCollateralPerAssetUnit = (collateralRatio * peggedValue) / priceInCurrencyPerAssetUnit
-        uint256 priceInCollateralPerAssetUnit = heart.getCollateralRatio(credit.collateralAssetCode()).mul(credit.peggedValue()).div(heart.getPriceFeeders().getMedianPrice(linkId));
+    function _calExchangeRate(IStableCredit credit, bytes32 linkId, uint256 stableCreditAmount) private view returns (uint256) {
+        // priceInCollateral = (collateralRatio * peggedValue * stableCreditAmount) / priceInCurrencyPerAssetUnit
+        uint256 priceInCollateralPerAssetUnit = heart.getCollateralRatio(credit.collateralAssetCode()).mul(credit.peggedValue()).mul(stableCreditAmount).div(heart.getPriceFeeders().getMedianPrice(linkId)).div(10000000);
         return (priceInCollateralPerAssetUnit);
     }
 }

--- a/go/cmd/gvel/layers/logic/redeem_stable_credit_test.go
+++ b/go/cmd/gvel/layers/logic/redeem_stable_credit_test.go
@@ -1,0 +1,229 @@
+package logic_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/velo-protocol/DRSv2/go/cmd/gvel/entity"
+	"github.com/velo-protocol/DRSv2/go/libs/vclient"
+	"testing"
+)
+
+func TestLogic_RedeemStableCredit(t *testing.T) {
+	var (
+		rpcURL              = "http://0.0.0.0:7575"
+		redeemAssetCode     = "vUSD"
+		redeemCreditAmount  = "104"
+		collateralAssetCode = "VELO"
+		collateralAmount    = "208"
+	)
+
+	mockedRedeemStableCreditInput := func() *entity.RedeemStableCreditInput {
+		return &entity.RedeemStableCreditInput{
+			RedeemAmount: redeemCreditAmount,
+			AssetCode:    redeemAssetCode,
+			Passphrase:   "password",
+		}
+	}
+
+	t.Run("success", func(t *testing.T) {
+		h := initTest(t)
+		defer h.done()
+
+		h.mockConfiguration.EXPECT().
+			GetDefaultAccount().
+			Return(accountEntity().PublicAddress)
+
+		h.mockDbRepo.EXPECT().
+			Get([]byte(accountEntity().PublicAddress)).
+			Return(accountsBytes(), nil)
+
+		h.mockConfiguration.EXPECT().
+			GetRpcUrl().
+			Return(rpcURL)
+
+		h.mockConfiguration.EXPECT().
+			GetDrsAddress().
+			Return("0x01")
+
+		h.mockConfiguration.EXPECT().
+			GetHeartAddress().
+			Return("0x02")
+
+		h.mockVFactory.EXPECT().
+			NewClient(&entity.NewClientInput{
+				RpcUrl:          rpcURL,
+				PrivateKey:      "6d71af6c908ff8b618825926f1004431915faf9b66238c30af9f86438d2bcd89",
+				ContractAddress: &vclient.ContractAddress{"0x01", "0x02"},
+			}).Return(h.mockVClient, nil)
+
+		h.mockVClient.EXPECT().
+			RedeemStableCredit(gomock.Any(), &vclient.RedeemStableCreditInput{
+				RedeemAmount: redeemCreditAmount,
+				AssetCode:     redeemAssetCode,
+			}).Return(&vclient.RedeemStableCreditOutput{
+			Tx:      &types.Transaction{},
+			Receipt: &types.Receipt{},
+			Event: &vclient.RedeemStableCreditEvent{
+				AssetCode:           "vUSD",
+				StableCreditAmount:  redeemCreditAmount,
+				CollateralAssetAddress:"0x03",
+				CollateralAssetCode: collateralAssetCode,
+				CollateralAmount:    collateralAmount,
+				Raw:                 nil,
+			},
+		}, nil)
+
+		output, err := h.logic.RedeemStableCredit(mockedRedeemStableCreditInput())
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, output)
+		assert.Equal(t, redeemAssetCode, output.AssetCode)
+		assert.Equal(t, "0xc5b2c658f5fa236c598a6e7fbf7f21413dc42e2a41dd982eb772b30707cba2eb", output.TxHash)
+		assert.Equal(t, redeemCreditAmount, output.RedeemAmount)
+	})
+
+	t.Run("fail, failed to load accounts from db", func(t *testing.T) {
+		h := initTest(t)
+		defer h.done()
+
+		h.mockConfiguration.EXPECT().
+			GetDefaultAccount().
+			Return(accountEntity().PublicAddress)
+
+		h.mockDbRepo.EXPECT().
+			Get([]byte(accountEntity().PublicAddress)).
+			Return(nil, errors.New("error here"))
+
+		output, err := h.logic.RedeemStableCredit(mockedRedeemStableCreditInput())
+
+		assert.Nil(t, output)
+		assert.Error(t, err)
+	})
+
+	t.Run("fail, failed to unmarshal stored data to entity", func(t *testing.T) {
+		h := initTest(t)
+		defer h.done()
+
+		badAccountByte, _ := json.Marshal("")
+
+		h.mockConfiguration.EXPECT().
+			GetDefaultAccount().
+			Return(accountEntity().PublicAddress)
+
+		h.mockDbRepo.EXPECT().
+			Get([]byte(accountEntity().PublicAddress)).
+			Return(badAccountByte, nil)
+
+		output, err := h.logic.RedeemStableCredit(mockedRedeemStableCreditInput())
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+	})
+
+	t.Run("fail, to decrypt the seed of passphrase", func(t *testing.T) {
+		h := initTest(t)
+		defer h.done()
+
+		h.mockConfiguration.EXPECT().
+			GetDefaultAccount().
+			Return(accountEntity().PublicAddress)
+
+		h.mockDbRepo.EXPECT().
+			Get([]byte(accountEntity().PublicAddress)).
+			Return(accountsBytes(), nil)
+
+		mockedBadPassphrase := mockedRedeemStableCreditInput()
+		mockedBadPassphrase.Passphrase = "bad passphrase"
+		output, err := h.logic.RedeemStableCredit(mockedBadPassphrase)
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		assert.Equal(t, fmt.Sprintf("failed to decrypt the private key of %s with given passphrase: failed to decipher and authenticate: cipher: message authentication failed", "0xf41E18a9573832265F74a671d3E275ec76790b5C"), err.Error())
+	})
+
+	t.Run("fail, connect to veloFactory.NewClient", func(t *testing.T) {
+		h := initTest(t)
+		defer h.done()
+
+		h.mockConfiguration.EXPECT().
+			GetDefaultAccount().
+			Return(accountEntity().PublicAddress)
+
+		h.mockDbRepo.EXPECT().
+			Get([]byte(accountEntity().PublicAddress)).
+			Return(accountsBytes(), nil)
+
+		h.mockConfiguration.EXPECT().
+			GetRpcUrl().
+			Return(rpcURL)
+
+		h.mockConfiguration.EXPECT().
+			GetDrsAddress().
+			Return("0x01")
+
+		h.mockConfiguration.EXPECT().
+			GetHeartAddress().
+			Return("0x02")
+
+		h.mockVFactory.EXPECT().
+			NewClient(&entity.NewClientInput{
+				RpcUrl:     rpcURL,
+				PrivateKey: "6d71af6c908ff8b618825926f1004431915faf9b66238c30af9f86438d2bcd89",
+				ContractAddress: &vclient.ContractAddress{
+					"0x01",
+					"0x02",
+				},
+			}).
+			Return(nil, errors.New("error here"))
+
+		output, err := h.logic.RedeemStableCredit(mockedRedeemStableCreditInput())
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+	})
+
+	t.Run("fail, connect to veloClient.RedeemStableCredit", func(t *testing.T) {
+		h := initTest(t)
+		defer h.done()
+
+		h.mockConfiguration.EXPECT().
+			GetDefaultAccount().
+			Return(accountEntity().PublicAddress)
+
+		h.mockDbRepo.EXPECT().
+			Get([]byte(accountEntity().PublicAddress)).
+			Return(accountsBytes(), nil)
+
+		h.mockConfiguration.EXPECT().
+			GetRpcUrl().
+			Return(rpcURL)
+
+		h.mockConfiguration.EXPECT().
+			GetDrsAddress().
+			Return("0x01")
+
+		h.mockConfiguration.EXPECT().
+			GetHeartAddress().
+			Return("0x02")
+
+		h.mockVFactory.EXPECT().
+			NewClient(&entity.NewClientInput{
+				RpcUrl:          rpcURL,
+				PrivateKey:      "6d71af6c908ff8b618825926f1004431915faf9b66238c30af9f86438d2bcd89",
+				ContractAddress: &vclient.ContractAddress{"0x01", "0x02"},
+			}).Return(h.mockVClient, nil)
+
+		h.mockVClient.EXPECT().
+			RedeemStableCredit(gomock.Any(), gomock.AssignableToTypeOf(&vclient.RedeemStableCreditInput{RedeemAmount:redeemCreditAmount, AssetCode: redeemAssetCode,})).
+			Return(nil, errors.New("error here"))
+
+		output, err := h.logic.RedeemStableCredit(mockedRedeemStableCreditInput())
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+	})
+}

--- a/go/libs/vclient/ivclient/mocks/mocked_interfaces.go
+++ b/go/libs/vclient/ivclient/mocks/mocked_interfaces.go
@@ -79,6 +79,21 @@ func (mr *MockVClientMockRecorder) MintFromStableCreditAmount(ctx, input interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintFromStableCreditAmount", reflect.TypeOf((*MockVClient)(nil).MintFromStableCreditAmount), ctx, input)
 }
 
+// RedeemStableCredit mocks base method
+func (m *MockVClient) RedeemStableCredit(ctx context.Context, input *vclient.RedeemStableCreditInput) (*vclient.RedeemStableCreditOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RedeemStableCredit", ctx, input)
+	ret0, _ := ret[0].(*vclient.RedeemStableCreditOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RedeemStableCredit indicates an expected call of RedeemStableCredit
+func (mr *MockVClientMockRecorder) RedeemStableCredit(ctx, input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RedeemStableCredit", reflect.TypeOf((*MockVClient)(nil).RedeemStableCredit), ctx, input)
+}
+
 // GetExchangeRate mocks base method
 func (m *MockVClient) GetExchangeRate(input *vclient.GetExchangeRateInput) (*vclient.GetExchangeRateOutput, error) {
 	m.ctrl.T.Helper()

--- a/go/libs/vclient/mocks/mocked_interfaces.go
+++ b/go/libs/vclient/mocks/mocked_interfaces.go
@@ -6,12 +6,12 @@ package mocks
 
 import (
 	context "context"
-	go_ethereum "github.com/ethereum/go-ethereum"
+	ethereum "github.com/ethereum/go-ethereum"
 	bind "github.com/ethereum/go-ethereum/accounts/abi/bind"
 	common "github.com/ethereum/go-ethereum/common"
 	types "github.com/ethereum/go-ethereum/core/types"
 	gomock "github.com/golang/mock/gomock"
-	abi "github.com/velo-protocol/DRSv2/go/abi"
+	vabi "github.com/velo-protocol/DRSv2/go/abi"
 	big "math/big"
 	reflect "reflect"
 )
@@ -55,7 +55,7 @@ func (mr *MockConnectionMockRecorder) CodeAt(ctx, contract, blockNumber interfac
 }
 
 // CallContract mocks base method
-func (m *MockConnection) CallContract(ctx context.Context, call go_ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+func (m *MockConnection) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CallContract", ctx, call, blockNumber)
 	ret0, _ := ret[0].([]byte)
@@ -115,7 +115,7 @@ func (mr *MockConnectionMockRecorder) SuggestGasPrice(ctx interface{}) *gomock.C
 }
 
 // EstimateGas mocks base method
-func (m *MockConnection) EstimateGas(ctx context.Context, call go_ethereum.CallMsg) (uint64, error) {
+func (m *MockConnection) EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EstimateGas", ctx, call)
 	ret0, _ := ret[0].(uint64)
@@ -144,7 +144,7 @@ func (mr *MockConnectionMockRecorder) SendTransaction(ctx, tx interface{}) *gomo
 }
 
 // FilterLogs mocks base method
-func (m *MockConnection) FilterLogs(ctx context.Context, query go_ethereum.FilterQuery) ([]types.Log, error) {
+func (m *MockConnection) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FilterLogs", ctx, query)
 	ret0, _ := ret[0].([]types.Log)
@@ -159,10 +159,10 @@ func (mr *MockConnectionMockRecorder) FilterLogs(ctx, query interface{}) *gomock
 }
 
 // SubscribeFilterLogs mocks base method
-func (m *MockConnection) SubscribeFilterLogs(ctx context.Context, query go_ethereum.FilterQuery, ch chan<- types.Log) (go_ethereum.Subscription, error) {
+func (m *MockConnection) SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubscribeFilterLogs", ctx, query, ch)
-	ret0, _ := ret[0].(go_ethereum.Subscription)
+	ret0, _ := ret[0].(ethereum.Subscription)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -526,10 +526,10 @@ func (mr *MockTxHelperMockRecorder) ConfirmTx(ctx, tx, from interface{}) *gomock
 }
 
 // ExtractSetupEvent mocks base method
-func (m *MockTxHelper) ExtractSetupEvent(eventName string, log *types.Log) (*abi.DigitalReserveSystemSetup, error) {
+func (m *MockTxHelper) ExtractSetupEvent(eventName string, log *types.Log) (*vabi.DigitalReserveSystemSetup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExtractSetupEvent", eventName, log)
-	ret0, _ := ret[0].(*abi.DigitalReserveSystemSetup)
+	ret0, _ := ret[0].(*vabi.DigitalReserveSystemSetup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -541,10 +541,10 @@ func (mr *MockTxHelperMockRecorder) ExtractSetupEvent(eventName, log interface{}
 }
 
 // ExtractMintEvent mocks base method
-func (m *MockTxHelper) ExtractMintEvent(eventName string, log *types.Log) (*abi.DigitalReserveSystemMint, error) {
+func (m *MockTxHelper) ExtractMintEvent(eventName string, log *types.Log) (*vabi.DigitalReserveSystemMint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExtractMintEvent", eventName, log)
-	ret0, _ := ret[0].(*abi.DigitalReserveSystemMint)
+	ret0, _ := ret[0].(*vabi.DigitalReserveSystemMint)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -556,10 +556,10 @@ func (mr *MockTxHelperMockRecorder) ExtractMintEvent(eventName, log interface{})
 }
 
 // ExtractRedeemEvent mocks base method
-func (m *MockTxHelper) ExtractRedeemEvent(eventName string, log *types.Log) (*abi.DigitalReserveSystemRedeem, error) {
+func (m *MockTxHelper) ExtractRedeemEvent(eventName string, log *types.Log) (*vabi.DigitalReserveSystemRedeem, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExtractRedeemEvent", eventName, log)
-	ret0, _ := ret[0].(*abi.DigitalReserveSystemRedeem)
+	ret0, _ := ret[0].(*vabi.DigitalReserveSystemRedeem)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -571,10 +571,10 @@ func (mr *MockTxHelperMockRecorder) ExtractRedeemEvent(eventName, log interface{
 }
 
 // ExtractRebalanceEvent mocks base method
-func (m *MockTxHelper) ExtractRebalanceEvent(eventName string, log *types.Log) (*abi.DigitalReserveSystemRebalance, error) {
+func (m *MockTxHelper) ExtractRebalanceEvent(eventName string, log *types.Log) (*vabi.DigitalReserveSystemRebalance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExtractRebalanceEvent", eventName, log)
-	ret0, _ := ret[0].(*abi.DigitalReserveSystemRebalance)
+	ret0, _ := ret[0].(*vabi.DigitalReserveSystemRebalance)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/go/libs/vclient/redeem_stable_credit.go
+++ b/go/libs/vclient/redeem_stable_credit.go
@@ -67,7 +67,7 @@ type RedeemStableCreditEvent struct {
 	CollateralAssetAddress string
 	CollateralAssetCode    string
 	CollateralAmount       string
-	Raw                    types.Log
+	Raw                    *types.Log
 }
 
 type RedeemStableCreditOutput struct {
@@ -115,7 +115,7 @@ func (c *Client) RedeemStableCredit(ctx context.Context, input *RedeemStableCred
 		CollateralAssetAddress: event.CollateralAssetAddress.String(),
 		CollateralAssetCode:    utils.Byte32ToString(event.CollateralAssetCode),
 		CollateralAmount:       utils.AmountToString(event.CollateralAmount),
-		Raw:                    event.Raw,
+		Raw:                    &event.Raw,
 	}
 	return &RedeemStableCreditOutput{
 		Tx:      tx,

--- a/go/libs/vclient/redeem_stable_credit.go
+++ b/go/libs/vclient/redeem_stable_credit.go
@@ -10,6 +10,7 @@ import (
 	"github.com/velo-protocol/DRSv2/go/libs/utils"
 	"math/big"
 	"regexp"
+	"strings"
 )
 
 type RedeemStableCreditInput struct {
@@ -31,7 +32,7 @@ func (i *RedeemStableCreditInput) Validate() error {
 		return errors.New("invalid redeemAmount format")
 	}
 	if !amount.IsPositive() {
-		return errors.New("redeemAmount must be positive")
+		return errors.New("amount must be greater than 0")
 	}
 
 	// validate AssetCode
@@ -91,11 +92,11 @@ func (c *Client) RedeemStableCredit(ctx context.Context, input *RedeemStableCred
 		abiInput.AssetCode,
 	)
 	if err != nil {
-		return nil, err
+		return nil, RedeemStableCreditReplaceError("smart contract call error", input, err)
 	}
 	receipt, err := c.txHelper.ConfirmTx(ctx, tx, opt.From)
 	if err != nil {
-		return nil, err
+		return nil, RedeemStableCreditReplaceError("confirm transaction error", input, err)
 	}
 
 	eventLog := utils.FindLogEvent(receipt.Logs, "Redeem(string,uint256,address,bytes32,uint256)")
@@ -121,4 +122,18 @@ func (c *Client) RedeemStableCredit(ctx context.Context, input *RedeemStableCred
 		Receipt: receipt,
 		Event:   redeemStableCreditEvent,
 	}, nil
+}
+
+func RedeemStableCreditReplaceError(prefix string, abiInput *RedeemStableCreditInput, err error) error {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "stableCredit not exist"):
+		return errors.Wrap(errors.Errorf("the stable credit %s is not found", abiInput.AssetCode), prefix)
+	case strings.Contains(msg, "valid price not found"):
+		return errors.New("valid price not found")
+	case strings.Contains(msg, "ERC20: burn amount exceeds balance"):
+		return errors.Wrap(errors.Errorf("the stable credit %s in your address is insufficient", abiInput.AssetCode), prefix)
+	default:
+		return errors.Wrap(err, prefix)
+	}
 }

--- a/go/libs/vclient/redeem_stable_credit.go
+++ b/go/libs/vclient/redeem_stable_credit.go
@@ -130,7 +130,7 @@ func RedeemStableCreditReplaceError(prefix string, abiInput *RedeemStableCreditI
 	case strings.Contains(msg, "stableCredit not exist"):
 		return errors.Wrap(errors.Errorf("the stable credit %s is not found", abiInput.AssetCode), prefix)
 	case strings.Contains(msg, "valid price not found"):
-		return errors.New("valid price not found")
+		return errors.Wrap(errors.New("valid price not found"), prefix)
 	case strings.Contains(msg, "ERC20: burn amount exceeds balance"):
 		return errors.Wrap(errors.Errorf("the stable credit %s in your address is insufficient", abiInput.AssetCode), prefix)
 	default:

--- a/go/libs/vclient/redeem_stable_credit.go
+++ b/go/libs/vclient/redeem_stable_credit.go
@@ -66,7 +66,7 @@ type RedeemStableCreditEvent struct {
 	CollateralAssetAddress string
 	CollateralAssetCode    string
 	CollateralAmount       string
-	Raw                    types.Log
+	Raw                    *types.Log
 }
 
 type RedeemStableCreditOutput struct {
@@ -114,7 +114,7 @@ func (c *Client) RedeemStableCredit(ctx context.Context, input *RedeemStableCred
 		CollateralAssetAddress: event.CollateralAssetAddress.String(),
 		CollateralAssetCode:    utils.Byte32ToString(event.CollateralAssetCode),
 		CollateralAmount:       utils.AmountToString(event.CollateralAmount),
-		Raw:                    event.Raw,
+		Raw:                    &event.Raw,
 	}
 	return &RedeemStableCreditOutput{
 		Tx:      tx,

--- a/go/libs/vclient/redeem_stable_credit_test.go
+++ b/go/libs/vclient/redeem_stable_credit_test.go
@@ -38,7 +38,7 @@ func TestValidateRedeemStableCredit(t *testing.T) {
 		err := redeemStableCreditInput.Validate()
 
 		assert.NotNil(t, err)
-		assert.Equal(t, "redeemAmount must be positive", err.Error())
+		assert.Equal(t, "amount must be greater than 0", err.Error())
 	})
 
 	t.Run("fail, should throw error assetCode must not be blank", func(t *testing.T) {

--- a/go/libs/vclient/redeem_stable_credit_test.go
+++ b/go/libs/vclient/redeem_stable_credit_test.go
@@ -231,3 +231,30 @@ func TestClient_RedeemStableCredit(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("cannot find redeem event from transaction receipt %s", tx.Hash().String()), err.Error())
 	})
 }
+
+func TestRedeemStableCreditReplaceError(t *testing.T) {
+	t.Run("parsing an error, stableCredit not exist", func(t *testing.T) {
+		err := RedeemStableCreditReplaceError("smart contract call error", &RedeemStableCreditInput{AssetCode: "vUSD"}, errors.New("stableCredit not exist"))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "the stable credit vUSD is not found")
+		assert.Contains(t, err.Error(), "smart contract call error")
+	})
+	t.Run("parsing an error, valid price not found", func(t *testing.T) {
+		err := RedeemStableCreditReplaceError("smart contract call error", nil, errors.New("valid price not found"))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "valid price not found")
+		assert.Contains(t, err.Error(), "smart contract call error")
+	})
+	t.Run("parsing an error, ERC20: burn amount exceeds balance", func(t *testing.T) {
+		err := RedeemStableCreditReplaceError("smart contract call error", &RedeemStableCreditInput{AssetCode: "vUSD"}, errors.New("ERC20: burn amount exceeds balance"))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "the stable credit vUSD in your address is insufficient")
+		assert.Contains(t, err.Error(), "smart contract call error")
+	})
+	t.Run("parsing an error, any error", func(t *testing.T) {
+		err := RedeemStableCreditReplaceError("smart contract call error", nil, errors.New("some error has occured"))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "some error has occured")
+		assert.Contains(t, err.Error(), "smart contract call error")
+	})
+}

--- a/test/js/core/TestDigitalReserveSystem.js
+++ b/test/js/core/TestDigitalReserveSystem.js
@@ -731,7 +731,7 @@ contract("DigitalReserveSystem test", async accounts => {
       );
       await mocks.priceFeeder.givenMethodReturnUint(
         priceFeeder.contract.methods.getMedianPrice(Web3.utils.fromAscii("")).encodeABI(),
-        10000000
+        18000000
       );
       await mocks.heart.givenMethodReturnAddress(
         heart.contract.methods.getReserveManager().encodeABI(),
@@ -747,11 +747,11 @@ contract("DigitalReserveSystem test", async accounts => {
       );
       await mocks.heart.givenMethodReturnUint(
         heart.contract.methods.getCollateralRatio(Web3.utils.fromAscii("")).encodeABI(),
-        10000000
+        13000000
       );
       await mocks.stableCreditVTHB.givenMethodReturnUint(
         stableCreditVTHB.contract.methods.peggedValue().encodeABI(),
-        10000000
+        1
       );
       await mocks.stableCreditVTHB.givenMethodReturnBool(
         stableCreditVTHB.contract.methods.redeem(accounts[0], 0, 0).encodeABI(),
@@ -762,17 +762,17 @@ contract("DigitalReserveSystem test", async accounts => {
         true
       );
 
-      const result = await drs.redeem(100000000, "vTHB");
+      const result = await drs.redeem(2000000000, "vTHB");
 
       truffleAssert.eventEmitted(result, 'Redeem', event => {
         const BN = web3.utils.BN;
         const eventMintAmount = new BN(event.stableCreditAmount).toNumber();
         const eventCollateralAmount = new BN(event.collateralAmount).toNumber();
         return event.assetCode === "vTHB"
-          && eventMintAmount === 100000000
+          && eventMintAmount === 2000000000
           && event.collateralAssetAddress === veloCollateralAsset.address
           && web3.utils.hexToUtf8(event.collateralAssetCode) === 'VELO'
-          && eventCollateralAmount === 100000000;
+          && eventCollateralAmount === 144;
       }, 'contract should emit the event correctly');
 
     });


### PR DESCRIPTION
add logic testing for redeem
```

GOROOT=/usr/local/go #gosetup
GOPATH=/Users/michael/go #gosetup
/usr/local/go/bin/go test -c -o /private/var/folders/h8/sj0jhj490xs749cttq3rnzqr0000gn/T/___redeem_stable_credit_test_go github.com/velo-protocol/DRSv2/go/cmd/gvel/layers/logic #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/h8/sj0jhj490xs749cttq3rnzqr0000gn/T/___redeem_stable_credit_test_go -test.v -test.run ^TestLogic_RedeemStableCredit$ #gosetup
=== RUN   TestLogic_RedeemStableCredit
=== RUN   TestLogic_RedeemStableCredit/success
=== RUN   TestLogic_RedeemStableCredit/fail,_failed_to_load_accounts_from_db
=== RUN   TestLogic_RedeemStableCredit/fail,_failed_to_unmarshal_stored_data_to_entity
=== RUN   TestLogic_RedeemStableCredit/fail,_to_decrypt_the_seed_of_passphrase
=== RUN   TestLogic_RedeemStableCredit/fail,_connect_to_veloFactory.NewClient
=== RUN   TestLogic_RedeemStableCredit/fail,_connect_to_veloClient.RedeemStableCredit
--- PASS: TestLogic_RedeemStableCredit (0.00s)
    --- PASS: TestLogic_RedeemStableCredit/success (0.00s)
    --- PASS: TestLogic_RedeemStableCredit/fail,_failed_to_load_accounts_from_db (0.00s)
    --- PASS: TestLogic_RedeemStableCredit/fail,_failed_to_unmarshal_stored_data_to_entity (0.00s)
    --- PASS: TestLogic_RedeemStableCredit/fail,_to_decrypt_the_seed_of_passphrase (0.00s)
    --- PASS: TestLogic_RedeemStableCredit/fail,_connect_to_veloFactory.NewClient (0.00s)
    --- PASS: TestLogic_RedeemStableCredit/fail,_connect_to_veloClient.RedeemStableCredit (0.00s)
PASS

Process finished with exit code 0

```