### PR TITLE
Rename from RedeemStableCredit to RedeemCredit in project folder

### DIFF
--- a/go/cmd/gvel/entity/credit.go
+++ b/go/cmd/gvel/entity/credit.go
@@ -59,12 +59,12 @@ type GetCreditExchangeOutput struct {
 	PriceInCollateralPerAssetUnit string
 }
 
-type RedeemStableCreditInput struct {
+type RedeemCreditInput struct {
 	RedeemAmount string
 	AssetCode    string
 	Passphrase   string
 }
-type RedeemStableCreditOutput struct {
+type RedeemCreditOutput struct {
 	RedeemAmount string
 	AssetCode    string
 	TxHash       string

--- a/go/cmd/gvel/layers/commands/credit/main.go
+++ b/go/cmd/gvel/layers/commands/credit/main.go
@@ -43,7 +43,7 @@ func (creditCommand *CommandHandler) Command() *cobra.Command {
 		creditCommand.GetSetupCommand(),
 		creditCommand.GetMintCreditByCollateralCommand(),
 		creditCommand.GetMintByCreditCommand(),
-		creditCommand.GetRedeemStableCreditCommand(),
+		creditCommand.GetRedeemCreditCommand(),
 		creditCommand.GetExchangeCommand(),
 	)
 
@@ -90,11 +90,11 @@ func (creditCommand *CommandHandler) GetExchangeCommand() *cobra.Command {
 	return command
 }
 
-func (creditCommand *CommandHandler) GetRedeemStableCreditCommand() *cobra.Command {
+func (creditCommand *CommandHandler) GetRedeemCreditCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   constants.CmdCreditRedeem,
 		Short: "Redeem stable credit to collateral Asset on Velo",
-		Run:   creditCommand.RedeemStableCredit,
+		Run:   creditCommand.RedeemCredit,
 	}
 
 	return command

--- a/go/cmd/gvel/layers/commands/credit/redeem_stable_credit.go
+++ b/go/cmd/gvel/layers/commands/credit/redeem_stable_credit.go
@@ -6,15 +6,15 @@ import (
 	"github.com/velo-protocol/DRSv2/go/cmd/gvel/utils/console"
 )
 
-func (creditCommand *CommandHandler) RedeemStableCredit(_ *cobra.Command, _ []string) {
-	redeemStableCreditInput := &entity.RedeemStableCreditInput{
+func (creditCommand *CommandHandler) RedeemCredit(_ *cobra.Command, _ []string) {
+	redeemStableCreditInput := &entity.RedeemCreditInput{
 		RedeemAmount: creditCommand.Prompt.RequestString("Please input amount of stable credit", nil),
 		AssetCode:    creditCommand.Prompt.RequestString("Please enter asset code of credit to be redeemed", nil),
 		Passphrase:   creditCommand.Prompt.RequestHiddenString("🔑 Please input passphrase", nil),
 	}
 
 	console.StartLoading("Redeeming stable credit")
-	output, err := creditCommand.Logic.RedeemStableCredit(redeemStableCreditInput)
+	output, err := creditCommand.Logic.RedeemCredit(redeemStableCreditInput)
 	console.StopLoading()
 
 	if err != nil {

--- a/go/cmd/gvel/layers/commands/credit/redeem_stable_credit_test.go
+++ b/go/cmd/gvel/layers/commands/credit/redeem_stable_credit_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestCommandHandler_RedeemStableCredit(t *testing.T) {
+func TestCommandHandler_RedeemCredit(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		h := initTest(t)
@@ -25,18 +25,18 @@ func TestCommandHandler_RedeemStableCredit(t *testing.T) {
 			Return("password")
 
 		h.mockLogic.EXPECT().
-			RedeemStableCredit(&entity.RedeemStableCreditInput{
+			RedeemCredit(&entity.RedeemCreditInput{
 				RedeemAmount: "104",
 				AssetCode:    "vUSD",
 				Passphrase:   "password",
 			}).
-			Return(&entity.RedeemStableCreditOutput{
+			Return(&entity.RedeemCreditOutput{
 				RedeemAmount: "104",
 				AssetCode:    "vUSD",
 				TxHash:       h.mockTx.Hash().String(),
 			}, nil)
 
-		h.commandHandler.RedeemStableCredit(nil, nil)
+		h.commandHandler.RedeemCredit(nil, nil)
 
 		logs := h.loggerHook.AllEntries()
 		assert.Len(t, logs, 2)
@@ -44,7 +44,7 @@ func TestCommandHandler_RedeemStableCredit(t *testing.T) {
 		assert.Equal(t, "🔗 Transaction Hash: "+h.mockTx.Hash().String(), logs[1].Message)
 	})
 
-	t.Run("fail, logic.RedeemStableCredit returns error", func(t *testing.T) {
+	t.Run("fail, logic.RedeemCredit returns error", func(t *testing.T) {
 		h := initTest(t)
 		defer h.done()
 
@@ -59,7 +59,7 @@ func TestCommandHandler_RedeemStableCredit(t *testing.T) {
 			Return("password")
 
 		h.mockLogic.EXPECT().
-			RedeemStableCredit(&entity.RedeemStableCreditInput{
+			RedeemCredit(&entity.RedeemCreditInput{
 				RedeemAmount: "104",
 				AssetCode:    "vUSD",
 				Passphrase:   "password",
@@ -67,7 +67,7 @@ func TestCommandHandler_RedeemStableCredit(t *testing.T) {
 			Return(nil, errors.New("some error has occurred"))
 
 		assert.PanicsWithValue(t, console.ExitError, func() {
-			h.commandHandler.RedeemStableCredit(nil, nil)
+			h.commandHandler.RedeemCredit(nil, nil)
 		})
 	})
 }

--- a/go/cmd/gvel/layers/logic/interface.go
+++ b/go/cmd/gvel/layers/logic/interface.go
@@ -17,7 +17,7 @@ type Logic interface {
 	SetupCredit(input *entity.SetupCreditInput) (*entity.SetupCreditOutput, error)
 	MintCreditByCollateral(input *entity.MintCreditByCollateralInput) (*entity.MintCreditByCollateralOutput, error)
 	MintCreditByCredit(input *entity.MintCreditByCreditInput) (*entity.MintCreditByCreditOutput, error)
-	RedeemStableCredit(input *entity.RedeemStableCreditInput) (*entity.RedeemStableCreditOutput, error)
+	RedeemCredit(input *entity.RedeemCreditInput) (*entity.RedeemCreditOutput, error)
 	GetCreditExchange(input *entity.GetCreditExchangeInput) (*entity.GetCreditExchangeOutput, error)
 
 	// Collateral

--- a/go/cmd/gvel/layers/logic/redeem_stable_credit.go
+++ b/go/cmd/gvel/layers/logic/redeem_stable_credit.go
@@ -10,7 +10,7 @@ import (
 	"github.com/velo-protocol/DRSv2/go/libs/vclient"
 )
 
-func (lo *logic) RedeemStableCredit(input *entity.RedeemStableCreditInput) (*entity.RedeemStableCreditOutput, error) {
+func (lo *logic) RedeemCredit(input *entity.RedeemCreditInput) (*entity.RedeemCreditOutput, error) {
 	defaultAccount := lo.AppConfig.GetDefaultAccount()
 	accountBytes, err := lo.DB.Get([]byte(defaultAccount))
 	if err != nil {
@@ -43,7 +43,7 @@ func (lo *logic) RedeemStableCredit(input *entity.RedeemStableCreditInput) (*ent
 	ctx, cancel := context.WithTimeout(context.Background(), constants.Timeout)
 	defer cancel()
 
-	output, err := veloClient.RedeemStableCredit(ctx, &vclient.RedeemStableCreditInput{
+	output, err := veloClient.RedeemCredit(ctx, &vclient.RedeemCreditInput{
 		RedeemAmount: input.RedeemAmount,
 		AssetCode:    input.AssetCode,
 	})
@@ -51,7 +51,7 @@ func (lo *logic) RedeemStableCredit(input *entity.RedeemStableCreditInput) (*ent
 		return nil, err
 	}
 
-	return &entity.RedeemStableCreditOutput{
+	return &entity.RedeemCreditOutput{
 		RedeemAmount: output.Event.StableCreditAmount,
 		AssetCode:    output.Event.AssetCode,
 		TxHash:       output.Tx.Hash().String(),

--- a/go/cmd/gvel/layers/logic/redeem_stable_credit_test.go
+++ b/go/cmd/gvel/layers/logic/redeem_stable_credit_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func TestLogic_RedeemStableCredit(t *testing.T) {
+func TestLogic_RedeemCredit(t *testing.T) {
 	var (
 		rpcURL              = "http://0.0.0.0:7575"
 		redeemAssetCode     = "vUSD"
@@ -21,8 +21,8 @@ func TestLogic_RedeemStableCredit(t *testing.T) {
 		collateralAmount    = "208"
 	)
 
-	mockedRedeemStableCreditInput := func() *entity.RedeemStableCreditInput {
-		return &entity.RedeemStableCreditInput{
+	mockedRedeemCreditInput := func() *entity.RedeemCreditInput {
+		return &entity.RedeemCreditInput{
 			RedeemAmount: redeemCreditAmount,
 			AssetCode:    redeemAssetCode,
 			Passphrase:   "password",
@@ -61,13 +61,13 @@ func TestLogic_RedeemStableCredit(t *testing.T) {
 			}).Return(h.mockVClient, nil)
 
 		h.mockVClient.EXPECT().
-			RedeemStableCredit(gomock.Any(), &vclient.RedeemStableCreditInput{
+			RedeemCredit(gomock.Any(), &vclient.RedeemCreditInput{
 				RedeemAmount: redeemCreditAmount,
 				AssetCode:     redeemAssetCode,
-			}).Return(&vclient.RedeemStableCreditOutput{
+			}).Return(&vclient.RedeemCreditOutput{
 			Tx:      &types.Transaction{},
 			Receipt: &types.Receipt{},
-			Event: &vclient.RedeemStableCreditEvent{
+			Event: &vclient.RedeemCreditEvent{
 				AssetCode:           "vUSD",
 				StableCreditAmount:  redeemCreditAmount,
 				CollateralAssetAddress:"0x03",
@@ -77,7 +77,7 @@ func TestLogic_RedeemStableCredit(t *testing.T) {
 			},
 		}, nil)
 
-		output, err := h.logic.RedeemStableCredit(mockedRedeemStableCreditInput())
+		output, err := h.logic.RedeemCredit(mockedRedeemCreditInput())
 
 		assert.NoError(t, err)
 		assert.NotEmpty(t, output)
@@ -98,7 +98,7 @@ func TestLogic_RedeemStableCredit(t *testing.T) {
 			Get([]byte(accountEntity().PublicAddress)).
 			Return(nil, errors.New("error here"))
 
-		output, err := h.logic.RedeemStableCredit(mockedRedeemStableCreditInput())
+		output, err := h.logic.RedeemCredit(mockedRedeemCreditInput())
 
 		assert.Nil(t, output)
 		assert.Error(t, err)
@@ -118,7 +118,7 @@ func TestLogic_RedeemStableCredit(t *testing.T) {
 			Get([]byte(accountEntity().PublicAddress)).
 			Return(badAccountByte, nil)
 
-		output, err := h.logic.RedeemStableCredit(mockedRedeemStableCreditInput())
+		output, err := h.logic.RedeemCredit(mockedRedeemCreditInput())
 
 		assert.Error(t, err)
 		assert.Nil(t, output)
@@ -136,9 +136,9 @@ func TestLogic_RedeemStableCredit(t *testing.T) {
 			Get([]byte(accountEntity().PublicAddress)).
 			Return(accountsBytes(), nil)
 
-		mockedBadPassphrase := mockedRedeemStableCreditInput()
+		mockedBadPassphrase := mockedRedeemCreditInput()
 		mockedBadPassphrase.Passphrase = "bad passphrase"
-		output, err := h.logic.RedeemStableCredit(mockedBadPassphrase)
+		output, err := h.logic.RedeemCredit(mockedBadPassphrase)
 
 		assert.Error(t, err)
 		assert.Nil(t, output)
@@ -180,13 +180,13 @@ func TestLogic_RedeemStableCredit(t *testing.T) {
 			}).
 			Return(nil, errors.New("error here"))
 
-		output, err := h.logic.RedeemStableCredit(mockedRedeemStableCreditInput())
+		output, err := h.logic.RedeemCredit(mockedRedeemCreditInput())
 
 		assert.Error(t, err)
 		assert.Nil(t, output)
 	})
 
-	t.Run("fail, connect to veloClient.RedeemStableCredit", func(t *testing.T) {
+	t.Run("fail, connect to veloClient.RedeemCredit", func(t *testing.T) {
 		h := initTest(t)
 		defer h.done()
 
@@ -218,10 +218,10 @@ func TestLogic_RedeemStableCredit(t *testing.T) {
 			}).Return(h.mockVClient, nil)
 
 		h.mockVClient.EXPECT().
-			RedeemStableCredit(gomock.Any(), gomock.AssignableToTypeOf(&vclient.RedeemStableCreditInput{RedeemAmount:redeemCreditAmount, AssetCode: redeemAssetCode,})).
+			RedeemCredit(gomock.Any(), gomock.AssignableToTypeOf(&vclient.RedeemCreditInput{RedeemAmount:redeemCreditAmount, AssetCode: redeemAssetCode,})).
 			Return(nil, errors.New("error here"))
 
-		output, err := h.logic.RedeemStableCredit(mockedRedeemStableCreditInput())
+		output, err := h.logic.RedeemCredit(mockedRedeemCreditInput())
 
 		assert.Error(t, err)
 		assert.Nil(t, output)

--- a/go/cmd/gvel/layers/mocks/logic.go
+++ b/go/cmd/gvel/layers/mocks/logic.go
@@ -167,19 +167,19 @@ func (mr *MockLogicMockRecorder) MintCreditByCredit(input interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintCreditByCredit", reflect.TypeOf((*MockLogic)(nil).MintCreditByCredit), input)
 }
 
-// RedeemStableCredit mocks base method
-func (m *MockLogic) RedeemStableCredit(input *entity.RedeemStableCreditInput) (*entity.RedeemStableCreditOutput, error) {
+// RedeemCredit mocks base method
+func (m *MockLogic) RedeemCredit(input *entity.RedeemCreditInput) (*entity.RedeemCreditOutput, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RedeemStableCredit", input)
-	ret0, _ := ret[0].(*entity.RedeemStableCreditOutput)
+	ret := m.ctrl.Call(m, "RedeemCredit", input)
+	ret0, _ := ret[0].(*entity.RedeemCreditOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// RedeemStableCredit indicates an expected call of RedeemStableCredit
-func (mr *MockLogicMockRecorder) RedeemStableCredit(input interface{}) *gomock.Call {
+// RedeemCredit indicates an expected call of RedeemCredit
+func (mr *MockLogicMockRecorder) RedeemCredit(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RedeemStableCredit", reflect.TypeOf((*MockLogic)(nil).RedeemStableCredit), input)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RedeemCredit", reflect.TypeOf((*MockLogic)(nil).RedeemCredit), input)
 }
 
 // GetCreditExchange mocks base method

--- a/go/libs/vclient/ivclient/mocks/mocked_interfaces.go
+++ b/go/libs/vclient/ivclient/mocks/mocked_interfaces.go
@@ -79,19 +79,19 @@ func (mr *MockVClientMockRecorder) MintFromStableCreditAmount(ctx, input interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintFromStableCreditAmount", reflect.TypeOf((*MockVClient)(nil).MintFromStableCreditAmount), ctx, input)
 }
 
-// RedeemStableCredit mocks base method
-func (m *MockVClient) RedeemStableCredit(ctx context.Context, input *vclient.RedeemStableCreditInput) (*vclient.RedeemStableCreditOutput, error) {
+// RedeemCredit mocks base method
+func (m *MockVClient) RedeemCredit(ctx context.Context, input *vclient.RedeemCreditInput) (*vclient.RedeemCreditOutput, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RedeemStableCredit", ctx, input)
-	ret0, _ := ret[0].(*vclient.RedeemStableCreditOutput)
+	ret := m.ctrl.Call(m, "RedeemCredit", ctx, input)
+	ret0, _ := ret[0].(*vclient.RedeemCreditOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// RedeemStableCredit indicates an expected call of RedeemStableCredit
-func (mr *MockVClientMockRecorder) RedeemStableCredit(ctx, input interface{}) *gomock.Call {
+// RedeemCredit indicates an expected call of RedeemCredit
+func (mr *MockVClientMockRecorder) RedeemCredit(ctx, input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RedeemStableCredit", reflect.TypeOf((*MockVClient)(nil).RedeemStableCredit), ctx, input)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RedeemCredit", reflect.TypeOf((*MockVClient)(nil).RedeemCredit), ctx, input)
 }
 
 // GetExchangeRate mocks base method

--- a/go/libs/vclient/ivclient/vclient.go
+++ b/go/libs/vclient/ivclient/vclient.go
@@ -9,7 +9,7 @@ type VClient interface {
 	SetupCredit(ctx context.Context, input *vclient.SetupCreditInput) (*vclient.SetupCreditOutput, error)
 	MintFromCollateralAmount(ctx context.Context, input *vclient.MintFromCollateralAmountInput) (*vclient.MintFromCollateralAmountCreditOutput, error)
 	MintFromStableCreditAmount(ctx context.Context, input *vclient.MintFromStableCreditAmountInput) (*vclient.MintFromStableCreditAmountCreditOutput, error)
-	RedeemStableCredit(ctx context.Context, input *vclient.RedeemStableCreditInput) (*vclient.RedeemStableCreditOutput, error)
+	RedeemCredit(ctx context.Context, input *vclient.RedeemCreditInput) (*vclient.RedeemCreditOutput, error)
 	GetExchangeRate(input *vclient.GetExchangeRateInput) (*vclient.GetExchangeRateOutput, error)
 	CollateralHealthCheck(input *vclient.CollateralHealthCheckInput) ([]vclient.CollateralHealthCheckOutput, error)
 	Rebalance(ctx context.Context, input *vclient.RebalanceInput) (*vclient.RebalanceOutput, error)

--- a/go/libs/vclient/redeem_stable_credit_example_test.go
+++ b/go/libs/vclient/redeem_stable_credit_example_test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 )
 
-func ExampleClient_RedeemStableCredit() {
+func ExampleClient_RedeemCredit() {
 	client, err := NewClient(smartContractUrl, "<PRIVATE_KEY>", ContractAddress{
 		DrsAddress:   "<DRS_CONTRACT_ADDRESS>",   // 0xBdA518a6245480652d1A217192EBB299C94F623f
 		HeartAddress: "<HEART_CONTRACT_ADDRESS>", // 0x1623C9c8600319E7CfAff0Ca1c4a05e1a61D954D
@@ -17,7 +17,7 @@ func ExampleClient_RedeemStableCredit() {
 		panic(err)
 	}
 
-	result, err := client.RedeemStableCredit(context.Background(), &RedeemStableCreditInput{
+	result, err := client.RedeemCredit(context.Background(), &RedeemCreditInput{
 		RedeemAmount: "104",
 		AssetCode:    "vUSD",
 	})

--- a/go/libs/vclient/redeem_stable_credit_test.go
+++ b/go/libs/vclient/redeem_stable_credit_test.go
@@ -15,16 +15,16 @@ import (
 	"testing"
 )
 
-func TestValidateRedeemStableCredit(t *testing.T) {
+func TestValidateRedeemCredit(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		redeemStableCreditInput := &RedeemStableCreditInput{RedeemAmount: "100", AssetCode: "vUSD"}
+		redeemStableCreditInput := &RedeemCreditInput{RedeemAmount: "100", AssetCode: "vUSD"}
 		err := redeemStableCreditInput.Validate()
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("fail, should throw error invalid redeemAmount format", func(t *testing.T) {
-		err := (&RedeemStableCreditInput{
+		err := (&RedeemCreditInput{
 			RedeemAmount: "10.12345678",
 			AssetCode:    "vUSD",
 		}).Validate()
@@ -34,7 +34,7 @@ func TestValidateRedeemStableCredit(t *testing.T) {
 	})
 
 	t.Run("fail, should throw error redeemAmount must be positive", func(t *testing.T) {
-		redeemStableCreditInput := &RedeemStableCreditInput{RedeemAmount: "-2", AssetCode: "vUSD"}
+		redeemStableCreditInput := &RedeemCreditInput{RedeemAmount: "-2", AssetCode: "vUSD"}
 		err := redeemStableCreditInput.Validate()
 
 		assert.NotNil(t, err)
@@ -42,7 +42,7 @@ func TestValidateRedeemStableCredit(t *testing.T) {
 	})
 
 	t.Run("fail, should throw error assetCode must not be blank", func(t *testing.T) {
-		redeemStableCreditInput := &RedeemStableCreditInput{RedeemAmount: "100", AssetCode: ""}
+		redeemStableCreditInput := &RedeemCreditInput{RedeemAmount: "100", AssetCode: ""}
 		err := redeemStableCreditInput.Validate()
 
 		assert.NotNil(t, err)
@@ -50,7 +50,7 @@ func TestValidateRedeemStableCredit(t *testing.T) {
 	})
 
 	t.Run("fail, should throw error invalid assetCode format", func(t *testing.T) {
-		redeemStableCreditInput := &RedeemStableCreditInput{RedeemAmount: "100", AssetCode: "BAD_ASSET_CODE"}
+		redeemStableCreditInput := &RedeemCreditInput{RedeemAmount: "100", AssetCode: "BAD_ASSET_CODE"}
 		err := redeemStableCreditInput.Validate()
 
 		assert.NotNil(t, err)
@@ -58,22 +58,22 @@ func TestValidateRedeemStableCredit(t *testing.T) {
 	})
 }
 
-func TestValidateRedeemStableCreditToAbiInput(t *testing.T) {
+func TestValidateRedeemCreditToAbiInput(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		redeemStableCreditInput := &RedeemStableCreditInput{RedeemAmount: "100", AssetCode: "vUSD"}
+		redeemStableCreditInput := &RedeemCreditInput{RedeemAmount: "100", AssetCode: "vUSD"}
 		abiInput := redeemStableCreditInput.ToAbiInput()
 
 		assert.NotNil(t, abiInput)
 	})
 }
 
-func TestClient_RedeemStableCredit(t *testing.T) {
+func TestClient_RedeemCredit(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		testHelper := testHelperWithMock(t)
 		defer testHelper.MockController.Finish()
 
-		input := &RedeemStableCreditInput{
+		input := &RedeemCreditInput{
 			RedeemAmount: "104",
 			AssetCode:    "vUSD",
 		}
@@ -103,7 +103,7 @@ func TestClient_RedeemStableCredit(t *testing.T) {
 				CollateralAmount:       big.NewInt(1040000000),
 			}, nil)
 
-		result, err := testHelper.Client.RedeemStableCredit(context.Background(), input)
+		result, err := testHelper.Client.RedeemCredit(context.Background(), input)
 		assert.NoError(t, err)
 		assert.NotNil(t, result.Tx)
 		assert.NotNil(t, result.Receipt)
@@ -114,7 +114,7 @@ func TestClient_RedeemStableCredit(t *testing.T) {
 		testHelper := testHelperWithMock(t)
 		defer testHelper.MockController.Finish()
 
-		result, err := testHelper.Client.RedeemStableCredit(context.Background(), &RedeemStableCreditInput{})
+		result, err := testHelper.Client.RedeemCredit(context.Background(), &RedeemCreditInput{})
 		assert.Error(t, err)
 		assert.Nil(t, result)
 	})
@@ -125,7 +125,7 @@ func TestClient_RedeemStableCredit(t *testing.T) {
 
 		expectedMsg := "some error has occurred"
 
-		input := &RedeemStableCreditInput{
+		input := &RedeemCreditInput{
 			RedeemAmount: "104",
 			AssetCode:    "vUSD",
 		}
@@ -135,7 +135,7 @@ func TestClient_RedeemStableCredit(t *testing.T) {
 			Redeem(gomock.AssignableToTypeOf(&bind.TransactOpts{}), abiInput.RedeemAmount, abiInput.AssetCode).
 			Return(nil, errors.New(expectedMsg))
 
-		result, err := testHelper.Client.RedeemStableCredit(context.Background(), input)
+		result, err := testHelper.Client.RedeemCredit(context.Background(), input)
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), expectedMsg)
@@ -147,7 +147,7 @@ func TestClient_RedeemStableCredit(t *testing.T) {
 
 		expectedMsg := "some error has occurred"
 
-		input := &RedeemStableCreditInput{
+		input := &RedeemCreditInput{
 			RedeemAmount: "104",
 			AssetCode:    "vUSD",
 		}
@@ -160,7 +160,7 @@ func TestClient_RedeemStableCredit(t *testing.T) {
 			ConfirmTx(gomock.AssignableToTypeOf(context.Background()), gomock.AssignableToTypeOf(&types.Transaction{}), gomock.AssignableToTypeOf(common.Address{})).
 			Return(nil, errors.New(expectedMsg))
 
-		result, err := testHelper.Client.RedeemStableCredit(context.Background(), input)
+		result, err := testHelper.Client.RedeemCredit(context.Background(), input)
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), expectedMsg)
@@ -172,7 +172,7 @@ func TestClient_RedeemStableCredit(t *testing.T) {
 
 		expectedMsg := "some error has occurred"
 
-		input := &RedeemStableCreditInput{
+		input := &RedeemCreditInput{
 			RedeemAmount: "104",
 			AssetCode:    "vUSD",
 		}
@@ -196,7 +196,7 @@ func TestClient_RedeemStableCredit(t *testing.T) {
 			ExtractRedeemEvent("Redeem", gomock.AssignableToTypeOf(&types.Log{})).
 			Return(nil, errors.New(expectedMsg))
 
-		result, err := testHelper.Client.RedeemStableCredit(context.Background(), input)
+		result, err := testHelper.Client.RedeemCredit(context.Background(), input)
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), expectedMsg)
@@ -206,7 +206,7 @@ func TestClient_RedeemStableCredit(t *testing.T) {
 		testHelper := testHelperWithMock(t)
 		defer testHelper.MockController.Finish()
 
-		input := &RedeemStableCreditInput{
+		input := &RedeemCreditInput{
 			RedeemAmount: "104",
 			AssetCode:    "vUSD",
 		}
@@ -225,34 +225,34 @@ func TestClient_RedeemStableCredit(t *testing.T) {
 				},
 			}, nil)
 
-		result, err := testHelper.Client.RedeemStableCredit(context.Background(), input)
+		result, err := testHelper.Client.RedeemCredit(context.Background(), input)
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Equal(t, fmt.Sprintf("cannot find redeem event from transaction receipt %s", tx.Hash().String()), err.Error())
 	})
 }
 
-func TestRedeemStableCreditReplaceError(t *testing.T) {
+func TestRedeemCreditReplaceError(t *testing.T) {
 	t.Run("parsing an error, stableCredit not exist", func(t *testing.T) {
-		err := RedeemStableCreditReplaceError("smart contract call error", &RedeemStableCreditInput{AssetCode: "vUSD"}, errors.New("stableCredit not exist"))
+		err := RedeemCreditReplaceError("smart contract call error", &RedeemCreditInput{AssetCode: "vUSD"}, errors.New("stableCredit not exist"))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "the stable credit vUSD is not found")
 		assert.Contains(t, err.Error(), "smart contract call error")
 	})
 	t.Run("parsing an error, valid price not found", func(t *testing.T) {
-		err := RedeemStableCreditReplaceError("smart contract call error", nil, errors.New("valid price not found"))
+		err := RedeemCreditReplaceError("smart contract call error", nil, errors.New("valid price not found"))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "valid price not found")
 		assert.Contains(t, err.Error(), "smart contract call error")
 	})
 	t.Run("parsing an error, ERC20: burn amount exceeds balance", func(t *testing.T) {
-		err := RedeemStableCreditReplaceError("smart contract call error", &RedeemStableCreditInput{AssetCode: "vUSD"}, errors.New("ERC20: burn amount exceeds balance"))
+		err := RedeemCreditReplaceError("smart contract call error", &RedeemCreditInput{AssetCode: "vUSD"}, errors.New("ERC20: burn amount exceeds balance"))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "the stable credit vUSD in your address is insufficient")
 		assert.Contains(t, err.Error(), "smart contract call error")
 	})
 	t.Run("parsing an error, any error", func(t *testing.T) {
-		err := RedeemStableCreditReplaceError("smart contract call error", nil, errors.New("some error has occured"))
+		err := RedeemCreditReplaceError("smart contract call error", nil, errors.New("some error has occured"))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "some error has occured")
 		assert.Contains(t, err.Error(), "smart contract call error")


### PR DESCRIPTION
Based off https://github.com/velo-protocol/DRSv2/pull/114

1. go/libs/vclient/redeem_stable_credit_test.go

```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/michael/go #gosetup
/usr/local/go/bin/go test -c -o /private/var/folders/h8/sj0jhj490xs749cttq3rnzqr0000gn/T/___redeem_stable_credit_test_go__2_ github.com/velo-protocol/DRSv2/go/libs/vclient #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/h8/sj0jhj490xs749cttq3rnzqr0000gn/T/___redeem_stable_credit_test_go__2_ -test.v -test.run "^TestValidateRedeemCredit|TestValidateRedeemCreditToAbiInput|TestClient_RedeemCredit|TestRedeemCreditReplaceError$" #gosetup
=== RUN   TestValidateRedeemCredit
=== RUN   TestValidateRedeemCredit/success
=== RUN   TestValidateRedeemCredit/fail,_should_throw_error_invalid_redeemAmount_format
=== RUN   TestValidateRedeemCredit/fail,_should_throw_error_redeemAmount_must_be_positive
=== RUN   TestValidateRedeemCredit/fail,_should_throw_error_assetCode_must_not_be_blank
=== RUN   TestValidateRedeemCredit/fail,_should_throw_error_invalid_assetCode_format
--- PASS: TestValidateRedeemCredit (0.00s)
    --- PASS: TestValidateRedeemCredit/success (0.00s)
    --- PASS: TestValidateRedeemCredit/fail,_should_throw_error_invalid_redeemAmount_format (0.00s)
    --- PASS: TestValidateRedeemCredit/fail,_should_throw_error_redeemAmount_must_be_positive (0.00s)
    --- PASS: TestValidateRedeemCredit/fail,_should_throw_error_assetCode_must_not_be_blank (0.00s)
    --- PASS: TestValidateRedeemCredit/fail,_should_throw_error_invalid_assetCode_format (0.00s)
=== RUN   TestValidateRedeemCreditToAbiInput
=== RUN   TestValidateRedeemCreditToAbiInput/success
--- PASS: TestValidateRedeemCreditToAbiInput (0.00s)
    --- PASS: TestValidateRedeemCreditToAbiInput/success (0.00s)
=== RUN   TestClient_RedeemCredit
=== RUN   TestClient_RedeemCredit/Success
=== RUN   TestClient_RedeemCredit/error,_validation_fail
=== RUN   TestClient_RedeemCredit/error,_Redeem()_function_returns_an_error
=== RUN   TestClient_RedeemCredit/error,_txHelper.ConfirmTx_returns_an_error
=== RUN   TestClient_RedeemCredit/error,_txHelper.ExtractRedeemEvent_returns_an_error
=== RUN   TestClient_RedeemCredit/error,_no_redeem_log_emitting
--- PASS: TestClient_RedeemCredit (0.03s)
    --- PASS: TestClient_RedeemCredit/Success (0.00s)
    --- PASS: TestClient_RedeemCredit/error,_validation_fail (0.00s)
    --- PASS: TestClient_RedeemCredit/error,_Redeem()_function_returns_an_error (0.01s)
    --- PASS: TestClient_RedeemCredit/error,_txHelper.ConfirmTx_returns_an_error (0.00s)
    --- PASS: TestClient_RedeemCredit/error,_txHelper.ExtractRedeemEvent_returns_an_error (0.00s)
    --- PASS: TestClient_RedeemCredit/error,_no_redeem_log_emitting (0.00s)
=== RUN   TestRedeemCreditReplaceError
=== RUN   TestRedeemCreditReplaceError/parsing_an_error,_stableCredit_not_exist
=== RUN   TestRedeemCreditReplaceError/parsing_an_error,_valid_price_not_found
=== RUN   TestRedeemCreditReplaceError/parsing_an_error,_ERC20:_burn_amount_exceeds_balance
=== RUN   TestRedeemCreditReplaceError/parsing_an_error,_any_error
--- PASS: TestRedeemCreditReplaceError (0.00s)
    --- PASS: TestRedeemCreditReplaceError/parsing_an_error,_stableCredit_not_exist (0.00s)
    --- PASS: TestRedeemCreditReplaceError/parsing_an_error,_valid_price_not_found (0.00s)
    --- PASS: TestRedeemCreditReplaceError/parsing_an_error,_ERC20:_burn_amount_exceeds_balance (0.00s)
    --- PASS: TestRedeemCreditReplaceError/parsing_an_error,_any_error (0.00s)
PASS

Process finished with exit code 0
```

2. go/libs/vclient/redeem_stable_credit_example_test.go

`eyeballing test `

3. go/cmd/gvel/layers/logic/redeem_stable_credit_test.go

```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/michael/go #gosetup
/usr/local/go/bin/go test -c -o /private/var/folders/h8/sj0jhj490xs749cttq3rnzqr0000gn/T/___redeem_stable_credit_test_go github.com/velo-protocol/DRSv2/go/cmd/gvel/layers/logic #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/h8/sj0jhj490xs749cttq3rnzqr0000gn/T/___redeem_stable_credit_test_go -test.v -test.run ^TestLogic_RedeemCredit$ #gosetup
=== RUN   TestLogic_RedeemCredit
=== RUN   TestLogic_RedeemCredit/success
=== RUN   TestLogic_RedeemCredit/fail,_failed_to_load_accounts_from_db
=== RUN   TestLogic_RedeemCredit/fail,_failed_to_unmarshal_stored_data_to_entity
=== RUN   TestLogic_RedeemCredit/fail,_to_decrypt_the_seed_of_passphrase
=== RUN   TestLogic_RedeemCredit/fail,_connect_to_veloFactory.NewClient
=== RUN   TestLogic_RedeemCredit/fail,_connect_to_veloClient.RedeemCredit
--- PASS: TestLogic_RedeemCredit (0.00s)
    --- PASS: TestLogic_RedeemCredit/success (0.00s)
    --- PASS: TestLogic_RedeemCredit/fail,_failed_to_load_accounts_from_db (0.00s)
    --- PASS: TestLogic_RedeemCredit/fail,_failed_to_unmarshal_stored_data_to_entity (0.00s)
    --- PASS: TestLogic_RedeemCredit/fail,_to_decrypt_the_seed_of_passphrase (0.00s)
    --- PASS: TestLogic_RedeemCredit/fail,_connect_to_veloFactory.NewClient (0.00s)
    --- PASS: TestLogic_RedeemCredit/fail,_connect_to_veloClient.RedeemCredit (0.00s)
PASS

Process finished with exit code 0
```

4. go/cmd/gvel/layers/commands/credit/redeem_stable_credit_test.go

```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/michael/go #gosetup
/usr/local/go/bin/go test -c -o /private/var/folders/h8/sj0jhj490xs749cttq3rnzqr0000gn/T/___redeem_stable_credit_test_go__1_ github.com/velo-protocol/DRSv2/go/cmd/gvel/layers/commands/credit #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/h8/sj0jhj490xs749cttq3rnzqr0000gn/T/___redeem_stable_credit_test_go__1_ -test.v -test.run ^TestCommandHandler_RedeemCredit$ #gosetup
=== RUN   TestCommandHandler_RedeemCredit
=== RUN   TestCommandHandler_RedeemCredit/success
=== RUN   TestCommandHandler_RedeemCredit/fail,_logic.RedeemCredit_returns_error
--- PASS: TestCommandHandler_RedeemCredit (0.00s)
    --- PASS: TestCommandHandler_RedeemCredit/success (0.00s)
    --- PASS: TestCommandHandler_RedeemCredit/fail,_logic.RedeemCredit_returns_error (0.00s)
PASS

Process finished with exit code 0
```