### PR TITLE
Hotfix for redeem renaming

### DIFF
--- a/go/cmd/gvel/layers/logic/redeem_stable_credit.go
+++ b/go/cmd/gvel/layers/logic/redeem_stable_credit.go
@@ -43,7 +43,7 @@ func (lo *logic) RedeemCredit(input *entity.RedeemCreditInput) (*entity.RedeemCr
 	ctx, cancel := context.WithTimeout(context.Background(), constants.Timeout)
 	defer cancel()
 
-	output, err := veloClient.RedeemCredit(ctx, &vclient.RedeemCreditInput{
+	output, err := veloClient.RedeemStableCredit(ctx, &vclient.RedeemStableCreditInput{
 		RedeemAmount: input.RedeemAmount,
 		AssetCode:    input.AssetCode,
 	})

--- a/go/cmd/gvel/layers/logic/redeem_stable_credit_test.go
+++ b/go/cmd/gvel/layers/logic/redeem_stable_credit_test.go
@@ -61,13 +61,13 @@ func TestLogic_RedeemCredit(t *testing.T) {
 			}).Return(h.mockVClient, nil)
 
 		h.mockVClient.EXPECT().
-			RedeemCredit(gomock.Any(), &vclient.RedeemCreditInput{
+			RedeemStableCredit(gomock.Any(), &vclient.RedeemStableCreditInput{
 				RedeemAmount: redeemCreditAmount,
 				AssetCode:    redeemAssetCode,
-			}).Return(&vclient.RedeemCreditOutput{
+			}).Return(&vclient.RedeemStableCreditOutput{
 			Tx:      &types.Transaction{},
 			Receipt: &types.Receipt{},
-			Event: &vclient.RedeemCreditEvent{
+			Event: &vclient.RedeemStableCreditEvent{
 				AssetCode:              "vUSD",
 				StableCreditAmount:     redeemCreditAmount,
 				CollateralAssetAddress: "0x03",
@@ -218,7 +218,7 @@ func TestLogic_RedeemCredit(t *testing.T) {
 			}).Return(h.mockVClient, nil)
 
 		h.mockVClient.EXPECT().
-			RedeemCredit(gomock.Any(), gomock.AssignableToTypeOf(&vclient.RedeemCreditInput{RedeemAmount: redeemCreditAmount, AssetCode: redeemAssetCode})).
+			RedeemStableCredit(gomock.Any(), gomock.AssignableToTypeOf(&vclient.RedeemStableCreditInput{RedeemAmount: redeemCreditAmount, AssetCode: redeemAssetCode})).
 			Return(nil, errors.New("error here"))
 
 		output, err := h.logic.RedeemCredit(mockedRedeemCreditInput())


### PR DESCRIPTION
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/michael/go #gosetup
/usr/local/go/bin/go test -c -o /private/var/folders/h8/sj0jhj490xs749cttq3rnzqr0000gn/T/___redeem_stable_credit_test_go github.com/velo-protocol/DRSv2/go/cmd/gvel/layers/logic #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/h8/sj0jhj490xs749cttq3rnzqr0000gn/T/___redeem_stable_credit_test_go -test.v -test.run ^TestLogic_RedeemCredit$ #gosetup
=== RUN   TestLogic_RedeemCredit
=== RUN   TestLogic_RedeemCredit/success
=== RUN   TestLogic_RedeemCredit/fail,_failed_to_load_accounts_from_db
=== RUN   TestLogic_RedeemCredit/fail,_failed_to_unmarshal_stored_data_to_entity
=== RUN   TestLogic_RedeemCredit/fail,_to_decrypt_the_seed_of_passphrase
=== RUN   TestLogic_RedeemCredit/fail,_connect_to_veloFactory.NewClient
=== RUN   TestLogic_RedeemCredit/fail,_connect_to_veloClient.RedeemCredit
--- PASS: TestLogic_RedeemCredit (0.00s)
    --- PASS: TestLogic_RedeemCredit/success (0.00s)
    --- PASS: TestLogic_RedeemCredit/fail,_failed_to_load_accounts_from_db (0.00s)
    --- PASS: TestLogic_RedeemCredit/fail,_failed_to_unmarshal_stored_data_to_entity (0.00s)
    --- PASS: TestLogic_RedeemCredit/fail,_to_decrypt_the_seed_of_passphrase (0.00s)
    --- PASS: TestLogic_RedeemCredit/fail,_connect_to_veloFactory.NewClient (0.00s)
    --- PASS: TestLogic_RedeemCredit/fail,_connect_to_veloClient.RedeemCredit (0.00s)
PASS

Process finished with exit code 0

```

and 

```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/michael/go #gosetup
/usr/local/go/bin/go test -c -o /private/var/folders/h8/sj0jhj490xs749cttq3rnzqr0000gn/T/___redeem_stable_credit_test_go__1_ github.com/velo-protocol/DRSv2/go/cmd/gvel/layers/commands/credit #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/h8/sj0jhj490xs749cttq3rnzqr0000gn/T/___redeem_stable_credit_test_go__1_ -test.v -test.run ^TestCommandHandler_RedeemCredit$ #gosetup
=== RUN   TestCommandHandler_RedeemCredit
=== RUN   TestCommandHandler_RedeemCredit/success
=== RUN   TestCommandHandler_RedeemCredit/fail,_logic.RedeemCredit_returns_error
--- PASS: TestCommandHandler_RedeemCredit (0.00s)
    --- PASS: TestCommandHandler_RedeemCredit/success (0.00s)
    --- PASS: TestCommandHandler_RedeemCredit/fail,_logic.RedeemCredit_returns_error (0.00s)
PASS

Process finished with exit code 0

```